### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/groups/new.js
+++ b/app/assets/javascripts/groups/new.js
@@ -1,14 +1,14 @@
 $(document).on('turbolinks:load', function(){
 
   var search_list = $("#user-search-result");
-
+  var selected_list = $(".chat-group-users");
 
   $(function() {
 
     function appendUser(user){
       var html = `<div class="chat-group-user clearfix">
                     <p class="chat-group-user__name">${user.name}</p>
-                    <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${user.id}data-user-name="${user.name}>追加</div>
+                    <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}"data-user-name="${user.name}">追加</div>
                   </div>`
       search_list.append(html);
     }
@@ -20,11 +20,14 @@ $(document).on('turbolinks:load', function(){
       search_list.append(html);
     }
 
-    function appendMsgToUser(msg){
-      var html = `<div class="chat-group-user clearfix">
-                    <p class="chat-group-user__name">${msg}</p>
-                  </div>`
-      search_list.append(html);
+    function appendSelectedName(user_id,user_name){
+      var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
+                    <input name='group[user_ids][]' type='hidden' value=${user_id}>
+                    <p class='chat-group-user__name'>${user_name}</p>
+                    <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
+                   </div>`            
+
+      selected_list.append(html);
     }
 
 
@@ -47,19 +50,43 @@ $(document).on('turbolinks:load', function(){
             });
           }
             else{
-              console.log("errror");
               appendErrMsgToUser(' 一致するユーザーが見つかりません');
             }
           })
         .fail(function() {
            alert('検索に失敗しました');
         });
-        
+       });
 
-    });
-    $(document).on('click','.chat-group-user__btn--add', function(){
-      console.log("moji") 
-   })
+      $(document).on('click','.chat-group-user__btn--add', function(){
+
+        var user_id = $(this).data('user-id');
+        var user_name = $(this).data('user-name');
+        console.log(user_id,user_name)
+        appendSelectedName(user_id, user_name);
+        $(this).parent().remove();
+
+     })
+     $(document).on('click','.user-search-remove',function(){
+      $(this).parent().remove();
+     })
+
+{/* <div class="chat-group-form__field--right">
+<!-- グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください -->
+<!-- この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します -->
+<div class="chat-group-users"><div class="chat-group-user clearfix js-chat-member" id="chat-group-user-8">
+                    <input name="group[user_ids][]" type="hidden" value="3">
+                    <p class="chat-group-user__name">tanaka</p>
+                    <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn">削除</div>
+                   </div></div>
+<div class="chat-group-user clearfix" id="chat-group-user-22"></div>
+<input name="chat_group[user_ids][]" type="hidden" value="22">
+<p class="chat-group-user__name">
+show
+</p>
+</div> */}
+
+
     
   });
 });

--- a/app/assets/javascripts/groups/new.js
+++ b/app/assets/javascripts/groups/new.js
@@ -1,15 +1,65 @@
 $(document).on('turbolinks:load', function(){
 
+  var search_list = $("#user-search-result");
+
+
   $(function() {
-  $("#user-search-field").on("keypress", function() {
-    var input = $("#user-search-field").val();
-    console.log(input);
+
+    function appendUser(user){
+      var html = `<div class="chat-group-user clearfix">
+                    <p class="chat-group-user__name">${user.name}</p>
+                    <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${user.id}data-user-name="${user.name}>追加</div>
+                  </div>`
+      search_list.append(html);
+    }
+
+    function appendErrMsgToUser(msg){
+      var html = `<div class="chat-group-user clearfix">
+                    <p class="chat-group-user__name">${msg}</p>
+                  </div>`
+      search_list.append(html);
+    }
+
+    function appendMsgToUser(msg){
+      var html = `<div class="chat-group-user clearfix">
+                    <p class="chat-group-user__name">${msg}</p>
+                  </div>`
+      search_list.append(html);
+    }
+
+
+    $("#user-search-field").on("keyup", function(e) {
+      var input = $("#user-search-field").val();
+        $.ajax({
+          type: 'GET',
+          url: '/users',
+          data: { keyword: input },
+          dataType: 'json'
+        })
+        
+        .done(function(users) {
+          $("#user-search-result").empty();
+          if (users.length !== 0) {
+            users.forEach(function(user){
+              appendUser(user);
+
+             
+            });
+          }
+            else{
+              console.log("errror");
+              appendErrMsgToUser(' 一致するユーザーが見つかりません');
+            }
+          })
+        .fail(function() {
+           alert('検索に失敗しました');
+        });
+        
+
+    });
+    $(document).on('click','.chat-group-user__btn--add', function(){
+      console.log("moji") 
+   })
+    
   });
 });
-
-});
-
-
-{/* <div class="chat-group-form__search clearfix">
-<input class="chat-group-form__input" id="user-search-field" placeholder="追加したいユーザー名を入力してください" type="text">
-</div> */}

--- a/app/assets/javascripts/groups/new.js
+++ b/app/assets/javascripts/groups/new.js
@@ -1,0 +1,15 @@
+$(document).on('turbolinks:load', function(){
+
+  $(function() {
+  $("#user-search-field").on("keypress", function() {
+    var input = $("#user-search-field").val();
+    console.log(input);
+  });
+});
+
+});
+
+
+{/* <div class="chat-group-form__search clearfix">
+<input class="chat-group-form__input" id="user-search-field" placeholder="追加したいユーザー名を入力してください" type="text">
+</div> */}

--- a/app/assets/javascripts/groups/new.js
+++ b/app/assets/javascripts/groups/new.js
@@ -62,31 +62,12 @@ $(document).on('turbolinks:load', function(){
 
         var user_id = $(this).data('user-id');
         var user_name = $(this).data('user-name');
-        console.log(user_id,user_name)
         appendSelectedName(user_id, user_name);
         $(this).parent().remove();
-
-     })
-     $(document).on('click','.user-search-remove',function(){
-      $(this).parent().remove();
-     })
-
-{/* <div class="chat-group-form__field--right">
-<!-- グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください -->
-<!-- この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します -->
-<div class="chat-group-users"><div class="chat-group-user clearfix js-chat-member" id="chat-group-user-8">
-                    <input name="group[user_ids][]" type="hidden" value="3">
-                    <p class="chat-group-user__name">tanaka</p>
-                    <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn">削除</div>
-                   </div></div>
-<div class="chat-group-user clearfix" id="chat-group-user-22"></div>
-<input name="chat_group[user_ids][]" type="hidden" value="22">
-<p class="chat-group-user__name">
-show
-</p>
-</div> */}
-
-
-    
+       })
+      
+      $(document).on('click','.user-search-remove',function(){
+        $(this).parent().remove();
+      })  
   });
 });

--- a/app/assets/javascripts/groups/new.js
+++ b/app/assets/javascripts/groups/new.js
@@ -26,11 +26,9 @@ $(document).on('turbolinks:load', function(){
                     <p class='chat-group-user__name'>${user_name}</p>
                     <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
                    </div>`            
-
       selected_list.append(html);
     }
-
-
+    
     $("#user-search-field").on("keyup", function(e) {
       var input = $("#user-search-field").val();
         $.ajax({

--- a/app/assets/stylesheets/modules/form.scss
+++ b/app/assets/stylesheets/modules/form.scss
@@ -16,9 +16,9 @@
         z-index:5;
       }
       &__image-box {
-        position:absolute;
+        position:relative;
         left:calc(100% - 205px);
-        top:0px;
+        top:-45px;
         z-index:10;
         background-color: $white;
         height: 40px;
@@ -27,7 +27,8 @@
           font-size: 20px;
           line-height: 40px;
           position:absolute;
-          top:620px;
+          top:0px;
+          left:160px;
         }
         .hidden {
           display: none;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -19,6 +19,10 @@ class GroupsController < ApplicationController
     end
   end
 
+  def edit
+    @users = @group.users.where.not(id: current_user.id)
+  end
+
   def update
     if @group.update(group_params)
       redirect_to group_messages_path(@group), notice: 'グループを編集しました'

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,5 @@
 class MessagesController < ApplicationController
-  before_action :set_group
+  before_action :set_group, :set_user
 
   def index
     @message = Message.new
@@ -25,5 +25,9 @@ class MessagesController < ApplicationController
 
   def set_group
     @group = Group.find(params[:group_id])
+  end
+
+  def set_user
+    @users = User.all
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where.not(id: current_user.id).where('name LIKE(?)', "%#{params[:keyword]}%")
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,14 @@
 class UsersController < ApplicationController
+
+  def index
+    @users = User.all
+    respond_to do |format|
+      format.html
+      format.json
+    end
+
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.all
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -23,10 +23,6 @@
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      -# = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-     
       .chat-group-users
       .chat-group-user.clearfix#chat-group-user-22
       %input{name:'chat_group[user_ids][]',type:'hidden',value:'22'}

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -15,7 +15,7 @@
       %label.chat-group-form__label{for:"chat_group_チャットメンバーを追加"}>チャットメンバーを追加
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        %input{class: 'chat-group-form__input', id:'user-search-field',placeholder: '追加したいユーザー名を入力してください',type:'text'}
+        %input{class: 'chat-group-form__input', id:'user-search-field',placeholder: '追加したいユーザー名を入力してください',type:'text',name:'keyword'}
       #user-search-result
 
 
@@ -24,15 +24,16 @@
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      -# = f.collection_check_boxes :user_ids, User.all, :id, :name
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+     
+      .chat-group-users
+      .chat-group-user.clearfix#chat-group-user-22
+      %input{name:'chat_group[user_ids][]',type:'hidden',value:'22'}
+      %p.chat-group-user__name
+        =current_user.name
+        
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,17 +11,14 @@
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+    .chat-group-form__field--left
+      %label.chat-group-form__label{for:"chat_group_チャットメンバーを追加"}>チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input{class: 'chat-group-form__input', id:'user-search-field',placeholder: '追加したいユーザー名を入力してください',type:'text'}
+      #user-search-result
+
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -18,17 +18,23 @@
         %input{class: 'chat-group-form__input', id:'user-search-field',placeholder: '追加したいユーザー名を入力してください',type:'text',name:'keyword'}
       #user-search-result
 
-
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      .chat-group-users
-      .chat-group-user.clearfix#chat-group-user-22
-      %input{name:'chat_group[user_ids][]',type:'hidden',value:'22'}
-      %p.chat-group-user__name
-        =current_user.name
-        
+      .chat-group-users    
+        .chat-group-user.clearfix#chat-group-user-current_user.id
+          = f.hidden_field :id,name:"group[user_ids][]",value:current_user.id
+          %p.chat-group-user__name
+            = current_user.name
+
+        -if @users
+          - @users.each do |user|
+            .chat-group-user.clearfix.js-chat-member#chat-group-user-8
+              %input{name:'chat_group[user.ids][]',type:'hidden',value: user.id}
+              %p.chat-group-user__name
+                =user.name
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,3 @@
 .chat-group-form
-  %h1 新規チャットグループ
+  %h1 チャットグループ編集
   =render partial: 'form', locals: {group: @group}

--- a/app/views/shared/_main-header.html.haml
+++ b/app/views/shared/_main-header.html.haml
@@ -8,6 +8,6 @@
         - @group.users.each do |user|
           %li.main-header__left-box__member-lists__list
             = user.name
-    =link_to "https://www.twitter.com/",class: "right-header" do
+    =link_to edit_group_path(current_user) ,class: "right-header" do
       .right-header__button
         Edit

--- a/app/views/shared/_main-header.html.haml
+++ b/app/views/shared/_main-header.html.haml
@@ -8,6 +8,6 @@
         - @group.users.each do |user|
           %li.main-header__left-box__member-lists__list
             = user.name
-    =link_to edit_group_path(current_user) ,class: "right-header" do
+    =link_to edit_group_path(@group) ,class: "right-header" do
       .right-header__button
         Edit

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -7,7 +7,7 @@
         = link_to new_group_path do
           = fa_icon 'pencil-square-o', class: 'icon'
       %li.list
-        = link_to edit_user_path do
+        = link_to edit_user_path(current_user) do
           = fa_icon 'cog', class: 'icon'
 
   .groups

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array! @users do |user|
-  json.id user.id
-  json.name user.name
+	json.id user.id
+	json.name user.name
 end

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array! @users do |user|
-	json.id user.id
+	json.id   user.id
 	json.name user.name
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
-  resource :user, only: [:edit, :update]
+  resources :users, only: [:edit, :update,:index] 
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# WHAT
グループのメンバー検索の際のインクリメンタルサーチ（検索をした際に非同期通信で候補が追加をされる仕組み）の機能の追加

※キャプチャ
・新規登録画面での検索、削除からグループへの追加完了まで
https://gyazo.com/9894bd34976b2486008ba9cae9e84a90
・edit画面へ遷移をした際の挙動
https://gyazo.com/9831635acf5f3fd4460fa6668d0aaf62
・edit画面での検索をした際の挙動
https://gyazo.com/f59f16ba28dad58b6b122245539ee3cc

# WHY
・グループを追加する際に多数のユーザーがいたとしても、直感的に選択をすることができる。
・検索をすばやく送ることができる。